### PR TITLE
Fix edge to edge insets and smooth bottom navigation transitions

### DIFF
--- a/app/src/main/java/dev/arkbuilders/rate/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/MainActivity.kt
@@ -2,6 +2,7 @@ package dev.arkbuilders.rate.presentation
 
 import android.content.Intent
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
@@ -19,6 +20,9 @@ class MainActivity : AppCompatActivity() {
             statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
             navigationBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
         )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
         setContent {
             ARKRateTheme {
                 Surface(color = MaterialTheme.colorScheme.background) {

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/MainScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/MainScreen.kt
@@ -6,12 +6,13 @@ package dev.arkbuilders.rate.presentation
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,7 +29,6 @@ import com.ramcosta.composedestinations.generated.NavGraphs
 import com.ramcosta.composedestinations.generated.destinations.SplashScreenDestination
 import com.ramcosta.composedestinations.generated.onboarding.destinations.OnboardingQuickCalculationScreenDestination
 import com.ramcosta.composedestinations.generated.onboarding.destinations.OnboardingQuickScreenDestination
-import com.ramcosta.composedestinations.generated.onboarding.destinations.OnboardingScreenDestination
 import com.ramcosta.composedestinations.generated.portfolio.destinations.PortfolioScreenDestination
 import com.ramcosta.composedestinations.generated.quick.destinations.AddQuickScreenDestination
 import com.ramcosta.composedestinations.generated.quick.destinations.QuickScreenDestination
@@ -44,6 +44,7 @@ import dev.arkbuilders.rate.core.presentation.ui.ConnectivityOfflineSnackbar
 import dev.arkbuilders.rate.core.presentation.ui.ConnectivityOfflineSnackbarVisuals
 import dev.arkbuilders.rate.core.presentation.ui.ConnectivityOnlineSnackbar
 import dev.arkbuilders.rate.core.presentation.ui.ConnectivityOnlineSnackbarVisuals
+import dev.arkbuilders.rate.core.presentation.ui.LocalAppScaffoldPadding
 import dev.arkbuilders.rate.core.presentation.utils.findActivity
 import dev.arkbuilders.rate.core.presentation.utils.keyboardAsState
 import dev.arkbuilders.rate.feature.onboarding.OnboardingExternalNavigator
@@ -54,13 +55,6 @@ import dev.arkbuilders.rate.feature.quickwidget.presentation.action.AddNewCalcul
 import dev.arkbuilders.rate.feature.quickwidget.presentation.action.AddNewCalculationAction.Companion.ADD_NEW_CALCULATION_GROUP_KEY
 import dev.arkbuilders.rate.presentation.navigation.AnimatedRateBottomNavigation
 import kotlinx.coroutines.flow.drop
-
-private val dontApplySafeDrawingPaddingRoutes =
-    listOf(
-        OnboardingScreenDestination.route,
-        OnboardingQuickScreenDestination.route,
-        OnboardingQuickCalculationScreenDestination.route,
-    )
 
 private val showBottomBarRoutes =
     listOf(
@@ -90,7 +84,6 @@ fun MainScreen() {
 
     val isKeyboardOpen by keyboardAsState()
     val bottomBarVisible = rememberSaveable { mutableStateOf(false) }
-    val applySafeDrawingPadding = remember { mutableStateOf(true) }
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route ?: NavGraphs.main.startRoute.route
@@ -100,20 +93,10 @@ fun MainScreen() {
             currentRoute.startsWith(it)
         }
 
-    applySafeDrawingPadding.value =
-        !dontApplySafeDrawingPaddingRoutes.any {
-            currentRoute.startsWith(it)
-        }
-
     if (isKeyboardOpen)
         bottomBarVisible.value = false
 
     Scaffold(
-        modifier =
-            Modifier
-                .let {
-                    if (applySafeDrawingPadding.value) it.safeDrawingPadding() else it
-                },
         snackbarHost = {
             SnackbarHost(
                 hostState = snackState,
@@ -149,50 +132,52 @@ fun MainScreen() {
                 bottomBarVisible = bottomBarVisible,
             )
         },
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
-    ) {
-        DestinationsNavHost(
-            engine = engine,
-            navController = navController,
-            start = SplashScreenDestination,
-            navGraph = NavGraphs.main,
-            modifier = Modifier.padding(it),
-        ) {
-            composable(OnboardingQuickScreenDestination) {
-                val externalNavigator =
-                    remember {
-                        object : OnboardingExternalNavigator {
-                            override fun navigateOnFinish() {
-                                destinationsNavigator.navigate(QuickScreenDestination) {
-                                    popUpTo(NavGraphs.main.startDestination) {
-                                        inclusive = true
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { appScaffoldPadding ->
+        CompositionLocalProvider(LocalAppScaffoldPadding provides appScaffoldPadding) {
+            DestinationsNavHost(
+                engine = engine,
+                navController = navController,
+                start = SplashScreenDestination,
+                navGraph = NavGraphs.main,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                composable(OnboardingQuickScreenDestination) {
+                    val externalNavigator =
+                        remember {
+                            object : OnboardingExternalNavigator {
+                                override fun navigateOnFinish() {
+                                    destinationsNavigator.navigate(QuickScreenDestination) {
+                                        popUpTo(NavGraphs.main.startDestination) {
+                                            inclusive = true
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                OnboardingQuickScreen(
-                    navigator = destinationsNavigator,
-                    externalNavigator = externalNavigator,
-                )
-            }
+                    OnboardingQuickScreen(
+                        navigator = destinationsNavigator,
+                        externalNavigator = externalNavigator,
+                    )
+                }
 
-            composable(QuickScreenDestination) {
-                val externalNavigator =
-                    remember {
-                        object : QuickExternalNavigator {
-                            override fun navigateToCalcOnboarding() {
-                                destinationsNavigator.navigate(
-                                    OnboardingQuickCalculationScreenDestination,
-                                )
+                composable(QuickScreenDestination) {
+                    val externalNavigator =
+                        remember {
+                            object : QuickExternalNavigator {
+                                override fun navigateToCalcOnboarding() {
+                                    destinationsNavigator.navigate(
+                                        OnboardingQuickCalculationScreenDestination,
+                                    )
+                                }
                             }
                         }
-                    }
-                QuickScreen(
-                    navigator = destinationsNavigator,
-                    resultRecipient = resultRecipient(longNavType),
-                    externalNavigator = externalNavigator,
-                )
+                    QuickScreen(
+                        navigator = destinationsNavigator,
+                        resultRecipient = resultRecipient(longNavType),
+                        externalNavigator = externalNavigator,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/navigation/BottomNavigation.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/navigation/BottomNavigation.kt
@@ -5,11 +5,20 @@ package dev.arkbuilders.rate.presentation.navigation
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.with
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -19,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -31,6 +41,8 @@ import com.ramcosta.composedestinations.generated.settings.destinations.Settings
 import dev.arkbuilders.rate.core.presentation.CoreRDrawable
 import dev.arkbuilders.rate.core.presentation.CoreRString
 import dev.arkbuilders.rate.core.presentation.theme.ArkColor
+
+private const val BOTTOM_BAR_ANIMATION_DURATION_MILLIS = 300
 
 sealed class BottomNavItem(
     @StringRes val title: Int,
@@ -68,14 +80,48 @@ fun AnimatedRateBottomNavigation(
 ) {
     AnimatedContent(
         targetState = bottomBarVisible.value,
-        transitionSpec = {
-            slideInVertically { height -> height } with
-                slideOutVertically { height -> height }
-        },
-    ) { expanded ->
-        if (expanded)
+        transitionSpec = { bottomBarTransition() },
+    ) { visible ->
+        if (visible) {
             RateBottomNavigation(currentRoute, onBottomBarItemClick)
+        } else {
+            BottomNavigationInsetSpacer()
+        }
     }
+}
+
+private fun AnimatedContentTransitionScope<Boolean>.bottomBarTransition(): ContentTransform =
+    (
+        slideInVertically(
+            animationSpec =
+                tween(
+                    durationMillis = BOTTOM_BAR_ANIMATION_DURATION_MILLIS,
+                    easing = FastOutSlowInEasing,
+                ),
+            initialOffsetY = { height -> height },
+        ) togetherWith
+            slideOutVertically(
+                animationSpec =
+                    tween(
+                        durationMillis = BOTTOM_BAR_ANIMATION_DURATION_MILLIS,
+                        easing = FastOutSlowInEasing,
+                    ),
+                targetOffsetY = { height -> height },
+            )
+    ).using(
+        SizeTransform(clip = false) { _, _ ->
+            tween(
+                durationMillis = BOTTOM_BAR_ANIMATION_DURATION_MILLIS,
+                easing = FastOutSlowInEasing,
+            )
+        },
+    )
+
+@Composable
+private fun BottomNavigationInsetSpacer() {
+    Spacer(
+        Modifier.windowInsetsBottomHeight(WindowInsets.safeDrawing),
+    )
 }
 
 @Composable

--- a/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/AppScaffoldInsets.kt
+++ b/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/AppScaffoldInsets.kt
@@ -3,7 +3,7 @@ package dev.arkbuilders.rate.core.presentation.ui
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
  * Insets produced by the app-level Scaffold. Screens use these values instead of padding the
  * navigation host, allowing scrollable content and backgrounds to remain edge-to-edge.
  */
-val LocalAppScaffoldPadding = staticCompositionLocalOf { PaddingValues(0.dp) }
+val LocalAppScaffoldPadding = compositionLocalOf { PaddingValues(0.dp) }
 
 @Composable
 fun appScaffoldContentWindowInsets(): WindowInsets {

--- a/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/AppScaffoldInsets.kt
+++ b/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/AppScaffoldInsets.kt
@@ -1,0 +1,47 @@
+package dev.arkbuilders.rate.core.presentation.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+/**
+ * Insets produced by the app-level Scaffold. Screens use these values instead of padding the
+ * navigation host, allowing scrollable content and backgrounds to remain edge-to-edge.
+ */
+val LocalAppScaffoldPadding = staticCompositionLocalOf { PaddingValues(0.dp) }
+
+@Composable
+fun appScaffoldContentWindowInsets(): WindowInsets {
+    val padding = LocalAppScaffoldPadding.current
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+
+    return with(density) {
+        WindowInsets(
+            left = padding.calculateLeftPadding(layoutDirection).roundToPx(),
+            top = padding.calculateTopPadding().roundToPx(),
+            right = padding.calculateRightPadding(layoutDirection).roundToPx(),
+            bottom = padding.calculateBottomPadding().roundToPx(),
+        )
+    }
+}
+
+fun PaddingValues.calculateStartPadding(layoutDirection: LayoutDirection): Dp =
+    if (layoutDirection == LayoutDirection.Ltr) {
+        calculateLeftPadding(layoutDirection)
+    } else {
+        calculateRightPadding(layoutDirection)
+    }
+
+fun PaddingValues.calculateEndPadding(layoutDirection: LayoutDirection): Dp =
+    if (layoutDirection == LayoutDirection.Ltr) {
+        calculateRightPadding(layoutDirection)
+    } else {
+        calculateLeftPadding(layoutDirection)
+    }

--- a/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/ArkBasicTextField.kt
+++ b/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/ArkBasicTextField.kt
@@ -26,6 +26,7 @@ fun ArkBasicTextField(
     leadingIcon: (@Composable () -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     visualTransformation: VisualTransformation = VisualTransformation.None,
+    readOnly: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     BasicTextField(
@@ -35,6 +36,7 @@ fun ArkBasicTextField(
         textStyle = textStyle,
         keyboardOptions = keyboardOptions,
         visualTransformation = visualTransformation,
+        readOnly = readOnly,
         interactionSource = interactionSource,
         singleLine = true,
     ) { innerTextField ->

--- a/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/LoadingScreen.kt
+++ b/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/LoadingScreen.kt
@@ -37,8 +37,8 @@ import androidx.compose.ui.unit.dp
 import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 
 @Composable
-fun LoadingScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+fun LoadingScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         InstaSpinner(
             size = 60.dp,
             color = dev.arkbuilders.rate.core.presentation.theme.ArkColor.Secondary,

--- a/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/NoResult.kt
+++ b/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/NoResult.kt
@@ -18,8 +18,8 @@ import dev.arkbuilders.rate.core.presentation.R
 import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 
 @Composable
-fun NoResult() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+fun NoResult(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(
                 modifier = Modifier.size(72.dp),

--- a/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/Search.kt
+++ b/core/presentation/src/main/java/dev/arkbuilders/rate/core/presentation/ui/Search.kt
@@ -27,6 +27,7 @@ fun SearchTextField(
     modifier: Modifier = Modifier,
     text: String = "",
     placeHolderText: String = stringResource(R.string.search),
+    readOnly: Boolean = false,
     onValueChange: (String) -> Unit = {},
 ) {
     Row(
@@ -49,6 +50,7 @@ fun SearchTextField(
                     .padding(end = 12.dp),
             value = text,
             onValueChange = onValueChange,
+            readOnly = readOnly,
             textStyle =
                 TextStyle.Default.copy(
                     color = ArkColor.TextPrimary,

--- a/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/pages/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/pages/OnboardingScreen.kt
@@ -12,12 +12,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -71,7 +75,12 @@ fun OnboardingScreen(navigator: DestinationsNavigator) {
     }
 
     Column(
-        modifier = Modifier.navigationBarsPadding(),
+        modifier =
+            Modifier.windowInsetsPadding(
+                WindowInsets.safeDrawing.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                ),
+            ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         HorizontalPager(

--- a/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quick/OnboardingQuickScreen.kt
+++ b/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quick/OnboardingQuickScreen.kt
@@ -4,10 +4,14 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -79,9 +83,16 @@ fun OnboardingQuickScreen(
     var portfolioRect by remember { (mutableStateOf<Rect?>(null)) }
     var pairAlertRect by remember { (mutableStateOf<Rect?>(null)) }
 
-    Column(modifier = Modifier.safeDrawingPadding()) {
+    Column(modifier = Modifier.fillMaxSize()) {
         QuickEmpty(
-            modifier = Modifier.weight(1f),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(
+                            WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
+                        ),
+                    ),
             calculateModifier =
                 Modifier.onGloballyPositioned { coordinates ->
                     calculateRect = coordinates.boundsInRoot()

--- a/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quickcalculation/OnboardingQuickCalculationScreen.kt
+++ b/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quickcalculation/OnboardingQuickCalculationScreen.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -39,6 +41,7 @@ import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -54,6 +57,9 @@ import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 import dev.arkbuilders.rate.core.presentation.ui.CurrencyInfoItem
 import dev.arkbuilders.rate.core.presentation.ui.ListHeader
 import dev.arkbuilders.rate.core.presentation.ui.SearchTextField
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.onboarding.di.OnboardingComponentHolder
 import dev.arkbuilders.rate.feature.onboarding.quick.MockBottomNavigation
 import dev.arkbuilders.rate.feature.onboarding.quick.MockQuickItem
@@ -136,7 +142,6 @@ fun OnboardingQuickCalculationScreen(navigator: DestinationsNavigator) {
         return
 
     Scaffold(
-        modifier = Modifier.safeDrawingPadding(),
         floatingActionButton = {
             FloatingActionButton(
                 contentColor = Color.White,
@@ -153,17 +158,28 @@ fun OnboardingQuickCalculationScreen(navigator: DestinationsNavigator) {
                 pairAlertModifier = Modifier,
             )
         },
-    ) {
-        Column(Modifier.padding(it)) {
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        val layoutDirection = LocalLayoutDirection.current
+        Column(
+            Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                ),
+        ) {
             SearchTextField(
                 modifier =
                     Modifier.padding(
-                        top = 16.dp,
+                        top = contentPadding.calculateTopPadding() + 16.dp,
                         start = 16.dp,
                         end = 16.dp,
                         bottom = 16.dp,
                     ),
                 text = "",
+                readOnly = true,
             ) {}
             Column(
                 modifier =
@@ -196,7 +212,16 @@ fun OnboardingQuickCalculationScreen(navigator: DestinationsNavigator) {
                 }
             }
             ListHeader(text = stringResource(CoreRString.all_currencies))
-            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                contentPadding =
+                    PaddingValues(
+                        bottom = contentPadding.calculateBottomPadding(),
+                    ),
+            ) {
                 items(state.currencies, key = { it.code }) { name ->
                     CurrencyInfoItem(name) { }
                 }

--- a/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quickcalculation/OnboardingQuickCalculationScreen.kt
+++ b/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quickcalculation/OnboardingQuickCalculationScreen.kt
@@ -14,10 +14,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -57,7 +59,6 @@ import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 import dev.arkbuilders.rate.core.presentation.ui.CurrencyInfoItem
 import dev.arkbuilders.rate.core.presentation.ui.ListHeader
 import dev.arkbuilders.rate.core.presentation.ui.SearchTextField
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
 import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.onboarding.di.OnboardingComponentHolder
@@ -158,7 +159,7 @@ fun OnboardingQuickCalculationScreen(navigator: DestinationsNavigator) {
                 pairAlertModifier = Modifier,
             )
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         val layoutDirection = LocalLayoutDirection.current
         Column(

--- a/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/spotlight/SpotlightTooltip.kt
+++ b/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/spotlight/SpotlightTooltip.kt
@@ -4,10 +4,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -25,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -34,6 +38,8 @@ import androidx.compose.ui.unit.sp
 import dev.arkbuilders.rate.core.presentation.CoreRString
 import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 import dev.arkbuilders.rate.core.presentation.ui.AppButton
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.ui.group.ArkOutlinedButton
 import kotlin.math.roundToInt
 
@@ -52,8 +58,14 @@ fun SpotlightTooltip(
     onSkip: (() -> Unit)? = null,
 ) {
     val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
     val screenHeightPx = with(density) { screenHeight.toPx() }
+    val safeDrawingPadding = WindowInsets.safeDrawing.asPaddingValues()
+    val safeTopPx = with(density) { safeDrawingPadding.calculateTopPadding().toPx() }
+    val safeBottomBoundary =
+        screenHeightPx -
+            with(density) { safeDrawingPadding.calculateBottomPadding().toPx() }
     val paddingPx = with(density) { targetPadding.toPx() }
 
     var tooltipHeightPx by remember { mutableStateOf(0f) }
@@ -63,21 +75,32 @@ fun SpotlightTooltip(
             val aboveY = targetRect.top - tooltipHeightPx - paddingPx
             val belowY = targetRect.bottom + paddingPx
 
-            when (position) {
-                TooltipPosition.Above -> {
-                    if (aboveY > 0) aboveY else belowY
+            val preferredY =
+                when (position) {
+                    TooltipPosition.Above -> {
+                        if (aboveY >= safeTopPx) aboveY else belowY
+                    }
+                    TooltipPosition.Below -> {
+                        if (belowY + tooltipHeightPx <= safeBottomBoundary) belowY else aboveY
+                    }
                 }
-                TooltipPosition.Below -> {
-                    if (belowY + tooltipHeightPx < screenHeightPx) belowY else aboveY
-                }
-            }
+
+            preferredY.coerceIn(
+                minimumValue = safeTopPx,
+                maximumValue =
+                    (safeBottomBoundary - tooltipHeightPx)
+                        .coerceAtLeast(safeTopPx),
+            )
         }
 
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(
+                    start = safeDrawingPadding.calculateStartPadding(layoutDirection) + 16.dp,
+                    end = safeDrawingPadding.calculateEndPadding(layoutDirection) + 16.dp,
+                )
                 .absoluteOffset { IntOffset(0, tooltipOffsetY.roundToInt()) },
     ) {
         Card(

--- a/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/add/AddPairAlertScreen.kt
+++ b/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/add/AddPairAlertScreen.kt
@@ -4,9 +4,13 @@ package dev.arkbuilders.rate.feature.pairalert.presentation.add
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -22,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
@@ -44,6 +49,9 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.DropDownWithIcon
 import dev.arkbuilders.rate.core.presentation.ui.GroupCreateDialog
 import dev.arkbuilders.rate.core.presentation.ui.GroupSelectPopup
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.pairalert.di.PairAlertComponentHolder
 import dev.arkbuilders.rate.feature.search.presentation.SearchNavResult
 import org.orbitmvi.orbit.compose.collectAsState
@@ -96,27 +104,28 @@ fun AddPairAlertScreen(
                 onBackClick = { navigator.popBackStack() },
             )
         },
-    ) {
-        Box(modifier = Modifier.padding(it)) {
-            Content(
-                state = state,
-                navigateSearchBase = viewModel::onNavigateSearchBase,
-                navigateSearchTarget = viewModel::onNavigateSearchTarget,
-                onGroupSelect = viewModel::onGroupSelect,
-                onGroupCreate = viewModel::onGroupCreate,
-                onPriceOrPercentChanged = viewModel::onPriceOrPercentChanged,
-                onOneTimeChanged = viewModel::onOneTimeChanged,
-                onPriceOrPercentInputChanged = viewModel::onPriceOrPercentInputChanged,
-                onIncreaseToggle = viewModel::onIncreaseToggle,
-                onSaveClick = viewModel::onSaveClick,
-            )
-        }
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Content(
+            state = state,
+            contentPadding = contentPadding,
+            navigateSearchBase = viewModel::onNavigateSearchBase,
+            navigateSearchTarget = viewModel::onNavigateSearchTarget,
+            onGroupSelect = viewModel::onGroupSelect,
+            onGroupCreate = viewModel::onGroupCreate,
+            onPriceOrPercentChanged = viewModel::onPriceOrPercentChanged,
+            onOneTimeChanged = viewModel::onOneTimeChanged,
+            onPriceOrPercentInputChanged = viewModel::onPriceOrPercentInputChanged,
+            onIncreaseToggle = viewModel::onIncreaseToggle,
+            onSaveClick = viewModel::onSaveClick,
+        )
     }
 }
 
 @Composable
 private fun Content(
     state: AddPairAlertScreenState,
+    contentPadding: PaddingValues,
     navigateSearchBase: () -> Unit,
     navigateSearchTarget: () -> Unit,
     onGroupSelect: (Group) -> Unit,
@@ -128,6 +137,7 @@ private fun Content(
     onSaveClick: () -> Unit,
 ) {
     val ctx = LocalContext.current
+    val layoutDirection = LocalLayoutDirection.current
     var showNewGroupDialog by remember { mutableStateOf(false) }
     var showGroupsPopup by remember { mutableStateOf(false) }
     var addGroupBtnWidth by remember { mutableStateOf(0) }
@@ -143,12 +153,23 @@ private fun Content(
         }
     }
 
-    Column {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .imePadding()
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                ),
+    ) {
         Column(
             modifier =
                 Modifier
                     .weight(1f)
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(rememberScrollState())
+                    .padding(top = contentPadding.calculateTopPadding()),
         ) {
             PriceOrPercent(state, onPriceOrPercentChanged)
             EditCondition(
@@ -206,7 +227,12 @@ private fun Content(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(
+                            start = 16.dp,
+                            top = 16.dp,
+                            end = 16.dp,
+                            bottom = contentPadding.calculateBottomPadding() + 16.dp,
+                        ),
                 onClick = onSaveClick,
                 enabled = state.finishEnabled,
             ) {

--- a/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/add/AddPairAlertScreen.kt
+++ b/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/add/AddPairAlertScreen.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -49,7 +51,6 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.DropDownWithIcon
 import dev.arkbuilders.rate.core.presentation.ui.GroupCreateDialog
 import dev.arkbuilders.rate.core.presentation.ui.GroupSelectPopup
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
 import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.pairalert.di.PairAlertComponentHolder
@@ -104,7 +105,7 @@ fun AddPairAlertScreen(
                 onBackClick = { navigator.popBackStack() },
             )
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         Content(
             state = state,

--- a/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/main/PairAlertConditionScreen.kt
+++ b/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/main/PairAlertConditionScreen.kt
@@ -9,9 +9,11 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.PagerState
@@ -51,7 +53,6 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarCenterTitle
 import dev.arkbuilders.rate.core.presentation.ui.GroupViewPager
 import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
 import dev.arkbuilders.rate.core.presentation.ui.RateSnackbarHost
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
 import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupOptionsBottomSheet
@@ -137,7 +138,7 @@ fun PairAlertConditionScreen(
         snackbarHost = {
             RateSnackbarHost(snackState)
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         Box(modifier = Modifier.fillMaxSize()) {
             when {

--- a/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/main/PairAlertConditionScreen.kt
+++ b/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/main/PairAlertConditionScreen.kt
@@ -8,6 +8,8 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,6 +33,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -48,6 +51,9 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarCenterTitle
 import dev.arkbuilders.rate.core.presentation.ui.GroupViewPager
 import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
 import dev.arkbuilders.rate.core.presentation.ui.RateSnackbarHost
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupOptionsBottomSheet
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupRenameBottomSheet
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupReorderBottomSheet
@@ -131,15 +137,31 @@ fun PairAlertConditionScreen(
         snackbarHost = {
             RateSnackbarHost(snackState)
         },
-    ) {
-        Box(modifier = Modifier.padding(it)) {
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
             when {
-                state.initialized.not() -> LoadingScreen()
-                isEmpty -> PairAlertEmpty(onNewPair = viewModel::onNewPair)
+                state.initialized.not() ->
+                    LoadingScreen(
+                        Modifier
+                            .padding(contentPadding)
+                            .consumeWindowInsets(contentPadding),
+                    )
+
+                isEmpty ->
+                    PairAlertEmpty(
+                        modifier =
+                            Modifier
+                                .padding(contentPadding)
+                                .consumeWindowInsets(contentPadding),
+                        onNewPair = viewModel::onNewPair,
+                    )
+
                 else ->
                     Content(
                         component = component,
                         state = state,
+                        contentPadding = contentPadding,
                         pagerState = pagerState,
                         onEditGroups = viewModel::onShowGroupsReorder,
                         onDelete = viewModel::onDelete,
@@ -204,13 +226,24 @@ fun PairAlertConditionScreen(
 private fun Content(
     component: PairAlertComponent,
     state: PairAlertScreenState,
+    contentPadding: PaddingValues,
     pagerState: PagerState,
     onEditGroups: () -> Unit,
     onDelete: (PairAlert) -> Unit,
     onClick: (PairAlert) -> Unit,
     onEnableToggle: (PairAlert, Boolean) -> Unit,
 ) {
-    Column {
+    val layoutDirection = LocalLayoutDirection.current
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                ),
+    ) {
         if (state.pages.size == 1) {
             GroupPage(
                 component = component,
@@ -218,9 +251,15 @@ private fun Content(
                 onDelete = { onDelete(it) },
                 onClick = onClick,
                 onEnableToggle = onEnableToggle,
+                contentPadding =
+                    PaddingValues(
+                        top = contentPadding.calculateTopPadding(),
+                        bottom = contentPadding.calculateBottomPadding(),
+                    ),
             )
         } else {
             GroupViewPager(
+                modifier = Modifier.padding(top = contentPadding.calculateTopPadding()),
                 pagerState = pagerState,
                 groups = state.pages.map { it.group },
                 onEditGroups = onEditGroups,
@@ -231,6 +270,10 @@ private fun Content(
                     onDelete = { onDelete(it) },
                     onClick = onClick,
                     onEnableToggle = onEnableToggle,
+                    contentPadding =
+                        PaddingValues(
+                            bottom = contentPadding.calculateBottomPadding(),
+                        ),
                 )
             }
         }
@@ -244,8 +287,12 @@ private fun GroupPage(
     onDelete: (PairAlert) -> Unit,
     onClick: (PairAlert) -> Unit,
     onEnableToggle: (PairAlert, Boolean) -> Unit,
+    contentPadding: PaddingValues,
 ) {
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = contentPadding,
+    ) {
         if (page.created.isNotEmpty()) {
             item {
                 Text(

--- a/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/main/PairAlertEmpty.kt
+++ b/feature/pairalert/src/main/java/dev/arkbuilders/rate/feature/pairalert/presentation/main/PairAlertEmpty.kt
@@ -22,8 +22,11 @@ import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 import dev.arkbuilders.rate.core.presentation.ui.AppButton
 
 @Composable
-fun PairAlertEmpty(onNewPair: () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize()) {
+fun PairAlertEmpty(
+    modifier: Modifier = Modifier,
+    onNewPair: () -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier.align(Alignment.Center),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/add/AddAssetScreen.kt
+++ b/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/add/AddAssetScreen.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -56,7 +58,6 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.DropDownWithIcon
 import dev.arkbuilders.rate.core.presentation.ui.GroupCreateDialog
 import dev.arkbuilders.rate.core.presentation.ui.GroupSelectPopup
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
 import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.portfolio.di.PortfolioComponentHolder
@@ -108,7 +109,7 @@ fun AddAssetScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         Content(
             state = state,

--- a/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/add/AddAssetScreen.kt
+++ b/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/add/AddAssetScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -53,6 +56,9 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.DropDownWithIcon
 import dev.arkbuilders.rate.core.presentation.ui.GroupCreateDialog
 import dev.arkbuilders.rate.core.presentation.ui.GroupSelectPopup
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.portfolio.di.PortfolioComponentHolder
 import dev.arkbuilders.rate.feature.portfolio.presentation.model.AddAssetsNavResult
 import dev.arkbuilders.rate.feature.search.presentation.SearchNavResult
@@ -102,25 +108,26 @@ fun AddAssetScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-    ) {
-        Box(modifier = Modifier.padding(it)) {
-            Content(
-                state = state,
-                onAssetValueChanged = viewModel::onAssetValueChange,
-                onNewCurrencyClick = viewModel::onAddCode,
-                onAssetRemove = viewModel::onAssetRemove,
-                onGroupSelect = viewModel::onGroupSelect,
-                onGroupCreate = viewModel::onGroupCreate,
-                onCodeChange = viewModel::onSetCode,
-                onAddAsset = viewModel::onAddAsset,
-            )
-        }
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Content(
+            state = state,
+            contentPadding = contentPadding,
+            onAssetValueChanged = viewModel::onAssetValueChange,
+            onNewCurrencyClick = viewModel::onAddCode,
+            onAssetRemove = viewModel::onAssetRemove,
+            onGroupSelect = viewModel::onGroupSelect,
+            onGroupCreate = viewModel::onGroupCreate,
+            onCodeChange = viewModel::onSetCode,
+            onAddAsset = viewModel::onAddAsset,
+        )
     }
 }
 
 @Composable
 private fun Content(
     state: AddAssetState,
+    contentPadding: PaddingValues,
     onAssetValueChanged: (Int, String) -> Unit,
     onNewCurrencyClick: () -> Unit,
     onAssetRemove: (Int) -> Unit,
@@ -130,6 +137,7 @@ private fun Content(
     onAddAsset: () -> Unit,
 ) {
     val ctx = LocalContext.current
+    val layoutDirection = LocalLayoutDirection.current
     var showNewGroupDialog by remember { mutableStateOf(false) }
     var showGroupsPopup by remember { mutableStateOf(false) }
     var addGroupBtnWidth by remember { mutableStateOf(0) }
@@ -148,12 +156,23 @@ private fun Content(
         )
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .imePadding()
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                ),
+    ) {
         Column(
             modifier =
                 Modifier
                     .weight(1f)
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(rememberScrollState())
+                    .padding(top = contentPadding.calculateTopPadding()),
         ) {
             Currencies(state, onAssetValueChanged, onAssetRemove, onCodeChange)
             Button(
@@ -230,7 +249,12 @@ private fun Content(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(
+                            start = 16.dp,
+                            top = 16.dp,
+                            end = 16.dp,
+                            bottom = contentPadding.calculateBottomPadding() + 16.dp,
+                        ),
                 onClick = {
                     onAddAsset()
                 },

--- a/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/edit/EditAssetScreen.kt
+++ b/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/edit/EditAssetScreen.kt
@@ -5,7 +5,11 @@ package dev.arkbuilders.rate.feature.portfolio.presentation.edit
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -24,6 +28,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -43,6 +48,9 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.ArkCursorLargeTextField
 import dev.arkbuilders.rate.core.presentation.ui.InfoDialog
 import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.portfolio.di.PortfolioComponentHolder
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -83,17 +91,23 @@ fun EditAssetScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-    ) {
-        Box(modifier = Modifier.padding(it)) {
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
             if (state.initialized) {
                 Content(
                     navigator = navigator,
                     info = state.info,
                     value = state.value,
+                    contentPadding = contentPadding,
                     onValueChange = viewModel::onValueChange,
                 )
             } else {
-                LoadingScreen()
+                LoadingScreen(
+                    Modifier
+                        .padding(contentPadding)
+                        .consumeWindowInsets(contentPadding),
+                )
             }
         }
     }
@@ -104,6 +118,7 @@ private fun Content(
     navigator: DestinationsNavigator,
     info: CurrencyInfo,
     value: String,
+    contentPadding: PaddingValues,
     onValueChange: (String) -> Unit,
 ) {
     var showMarketCapitalizationDialog by remember { mutableStateOf(false) }
@@ -111,6 +126,7 @@ private fun Content(
 
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
+    val layoutDirection = LocalLayoutDirection.current
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -135,8 +151,16 @@ private fun Content(
     Column(
         modifier =
             Modifier
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState()),
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection) + 16.dp,
+                    top = contentPadding.calculateTopPadding(),
+                    end = contentPadding.calculateEndPadding(layoutDirection) + 16.dp,
+                    bottom = contentPadding.calculateBottomPadding(),
+                ),
     ) {
         val title =
             if (info.name.isNotEmpty()) {

--- a/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/edit/EditAssetScreen.kt
+++ b/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/edit/EditAssetScreen.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -48,7 +50,6 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.ArkCursorLargeTextField
 import dev.arkbuilders.rate.core.presentation.ui.InfoDialog
 import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
 import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.portfolio.di.PortfolioComponentHolder
@@ -91,7 +92,7 @@ fun EditAssetScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         Box(modifier = Modifier.fillMaxSize()) {
             if (state.initialized) {

--- a/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/main/PortfolioEmpty.kt
+++ b/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/main/PortfolioEmpty.kt
@@ -24,8 +24,11 @@ import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 import dev.arkbuilders.rate.core.presentation.ui.AppButton
 
 @Composable
-fun PortfolioEmpty(navigator: DestinationsNavigator) {
-    Box(modifier = Modifier.fillMaxSize()) {
+fun PortfolioEmpty(
+    navigator: DestinationsNavigator,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier.align(Alignment.Center),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/main/PortfolioScreen.kt
+++ b/feature/portfolio/src/main/java/dev/arkbuilders/rate/feature/portfolio/presentation/main/PortfolioScreen.kt
@@ -7,11 +7,14 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -39,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -67,6 +71,9 @@ import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
 import dev.arkbuilders.rate.core.presentation.ui.NoResult
 import dev.arkbuilders.rate.core.presentation.ui.RateSnackbarHost
 import dev.arkbuilders.rate.core.presentation.ui.SearchTextField
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupOptionsBottomSheet
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupRenameBottomSheet
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupReorderBottomSheet
@@ -148,14 +155,30 @@ fun PortfolioScreen(
         snackbarHost = {
             RateSnackbarHost(snackState)
         },
-    ) {
-        Box(modifier = Modifier.padding(it)) {
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
             when {
-                state.initialized.not() -> LoadingScreen()
-                isEmpty -> PortfolioEmpty(navigator)
+                state.initialized.not() ->
+                    LoadingScreen(
+                        Modifier
+                            .padding(contentPadding)
+                            .consumeWindowInsets(contentPadding),
+                    )
+
+                isEmpty ->
+                    PortfolioEmpty(
+                        navigator = navigator,
+                        modifier =
+                            Modifier
+                                .padding(contentPadding)
+                                .consumeWindowInsets(contentPadding),
+                    )
+
                 else ->
                     Content(
                         state = state,
+                        contentPadding = contentPadding,
                         pagerState = pagerState,
                         onEditGroups = viewModel::onShowGroupsReorder,
                         onClick = { display ->
@@ -226,6 +249,7 @@ fun PortfolioScreen(
 @Composable
 private fun Content(
     state: PortfolioScreenState,
+    contentPadding: PaddingValues,
     pagerState: PagerState,
     onEditGroups: () -> Unit,
     onClick: (PortfolioDisplayAsset) -> Unit,
@@ -234,11 +258,22 @@ private fun Content(
     onDelete: (Asset) -> Unit,
 ) {
     val groups = state.pages.map { it.group }
-    Column {
+    val layoutDirection = LocalLayoutDirection.current
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .imePadding()
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                ),
+    ) {
         SearchTextField(
             modifier =
                 Modifier.padding(
-                    top = 16.dp,
+                    top = contentPadding.calculateTopPadding() + 16.dp,
                     start = 16.dp,
                     end = 16.dp,
                     bottom = 16.dp,
@@ -254,6 +289,10 @@ private fun Content(
                 onClick = onClick,
                 onChangeBaseCurrency = onChangeBaseCurrency,
                 onDelete = onDelete,
+                contentPadding =
+                    PaddingValues(
+                        bottom = contentPadding.calculateBottomPadding(),
+                    ),
             )
         } else {
             GroupViewPager(
@@ -268,6 +307,10 @@ private fun Content(
                     onClick = onClick,
                     onChangeBaseCurrency = onChangeBaseCurrency,
                     onDelete = onDelete,
+                    contentPadding =
+                        PaddingValues(
+                            bottom = contentPadding.calculateBottomPadding(),
+                        ),
                 )
             }
         }
@@ -282,6 +325,7 @@ private fun GroupPage(
     onClick: (PortfolioDisplayAsset) -> Unit = {},
     onChangeBaseCurrency: () -> Unit,
     onDelete: (Asset) -> Unit,
+    contentPadding: PaddingValues,
 ) {
     val total =
         amounts.fold(BigDecimal.ZERO) { acc, amount ->
@@ -292,6 +336,7 @@ private fun GroupPage(
     if (filtered.isNotEmpty()) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (filter.isEmpty()) {
@@ -373,6 +418,10 @@ private fun GroupPage(
             }
         }
     } else {
-        NoResult()
+        NoResult(
+            Modifier
+                .padding(contentPadding)
+                .consumeWindowInsets(contentPadding),
+        )
     }
 }

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickScreen.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickScreen.kt
@@ -9,12 +9,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -61,7 +63,6 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.DropDownWithIcon
 import dev.arkbuilders.rate.core.presentation.ui.GroupCreateDialog
 import dev.arkbuilders.rate.core.presentation.ui.GroupSelectPopup
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
 import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.utils.ReorderHapticFeedbackType
@@ -126,7 +127,7 @@ fun AddQuickScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         Content(
             state = state,

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickScreen.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickScreen.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -32,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -58,6 +61,9 @@ import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
 import dev.arkbuilders.rate.core.presentation.ui.DropDownWithIcon
 import dev.arkbuilders.rate.core.presentation.ui.GroupCreateDialog
 import dev.arkbuilders.rate.core.presentation.ui.GroupSelectPopup
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.utils.ReorderHapticFeedbackType
 import dev.arkbuilders.rate.core.presentation.utils.rememberReorderHapticFeedback
 import dev.arkbuilders.rate.feature.quick.di.QuickComponentHolder
@@ -120,27 +126,28 @@ fun AddQuickScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-    ) {
-        Box(modifier = Modifier.padding(it)) {
-            Content(
-                state = state,
-                onAmountChanged = viewModel::onAssetAmountChange,
-                onNewCurrencyClick = viewModel::onAddCode,
-                onCurrencyRemove = viewModel::onCurrencyRemove,
-                onGroupSelect = viewModel::onGroupSelect,
-                onGroupCreate = viewModel::onGroupCreate,
-                onCodeChange = viewModel::onSetCode,
-                onSwapClick = viewModel::onSwapClick,
-                onCurrenciesSwap = viewModel::onCurrenciesSwap,
-                onAddAsset = viewModel::onAddQuickCalculation,
-            )
-        }
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Content(
+            state = state,
+            contentPadding = contentPadding,
+            onAmountChanged = viewModel::onAssetAmountChange,
+            onNewCurrencyClick = viewModel::onAddCode,
+            onCurrencyRemove = viewModel::onCurrencyRemove,
+            onGroupSelect = viewModel::onGroupSelect,
+            onGroupCreate = viewModel::onGroupCreate,
+            onCodeChange = viewModel::onSetCode,
+            onSwapClick = viewModel::onSwapClick,
+            onCurrenciesSwap = viewModel::onCurrenciesSwap,
+            onAddAsset = viewModel::onAddQuickCalculation,
+        )
     }
 }
 
 @Composable
 private fun Content(
     state: AddQuickScreenState,
+    contentPadding: PaddingValues,
     onAmountChanged: (String) -> Unit,
     onNewCurrencyClick: () -> Unit,
     onCurrencyRemove: (Int) -> Unit,
@@ -152,6 +159,7 @@ private fun Content(
     onAddAsset: () -> Unit,
 ) {
     val ctx = LocalContext.current
+    val layoutDirection = LocalLayoutDirection.current
     var showNewGroupDialog by remember { mutableStateOf(false) }
     var showGroupsPopup by remember { mutableStateOf(false) }
     var addGroupBtnWidth by remember { mutableStateOf(0) }
@@ -177,12 +185,26 @@ private fun Content(
             haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
         }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .imePadding()
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                ),
+    ) {
         LazyColumn(
             modifier =
                 Modifier
                     .weight(1f),
             state = lazyListState,
+            contentPadding =
+                PaddingValues(
+                    top = contentPadding.calculateTopPadding(),
+                ),
         ) {
             currencies(
                 state,
@@ -270,7 +292,12 @@ private fun Content(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(
+                            start = 16.dp,
+                            top = 16.dp,
+                            end = 16.dp,
+                            bottom = contentPadding.calculateBottomPadding() + 16.dp,
+                        ),
                 onClick = {
                     onAddAsset()
                 },
@@ -287,6 +314,7 @@ private fun Content(
 fun Preview() {
     Content(
         state = AddQuickScreenState(),
+        contentPadding = PaddingValues(),
         onAmountChanged = {},
         onNewCurrencyClick = {},
         onCurrencyRemove = {},

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickEmpty.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickEmpty.kt
@@ -24,8 +24,11 @@ import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 import dev.arkbuilders.rate.core.presentation.ui.AppButton
 
 @Composable
-fun QuickEmpty(navigator: DestinationsNavigator) {
-    Box(modifier = Modifier.fillMaxSize()) {
+fun QuickEmpty(
+    navigator: DestinationsNavigator,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier.align(Alignment.Center),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickScreen.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickScreen.kt
@@ -3,7 +3,10 @@ package dev.arkbuilders.rate.feature.quick.presentation.main
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -25,6 +28,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -47,6 +51,9 @@ import dev.arkbuilders.rate.core.presentation.ui.ListHeader
 import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
 import dev.arkbuilders.rate.core.presentation.ui.RateSnackbarHost
 import dev.arkbuilders.rate.core.presentation.ui.SearchTextField
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupOptionsBottomSheet
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupRenameBottomSheet
 import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupReorderBottomSheet
@@ -139,14 +146,30 @@ fun QuickScreen(
         snackbarHost = {
             RateSnackbarHost(snackState)
         },
-    ) {
-        Box(modifier = Modifier.padding(it)) {
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
             when {
-                state.initialized.not() -> LoadingScreen()
-                isEmpty -> QuickEmpty(navigator)
+                state.initialized.not() ->
+                    LoadingScreen(
+                        Modifier
+                            .padding(contentPadding)
+                            .consumeWindowInsets(contentPadding),
+                    )
+
+                isEmpty ->
+                    QuickEmpty(
+                        navigator = navigator,
+                        modifier =
+                            Modifier
+                                .padding(contentPadding)
+                                .consumeWindowInsets(contentPadding),
+                    )
+
                 else ->
                     Content(
                         state = state,
+                        contentPadding = contentPadding,
                         pagerState = pagerState,
                         onEditGroups = viewModel::onShowGroupsReorder,
                         onFilterChanged = viewModel::onFilterChanged,
@@ -240,6 +263,7 @@ fun QuickScreen(
 @Composable
 private fun Content(
     state: QuickScreenState,
+    contentPadding: PaddingValues,
     pagerState: PagerState,
     onEditGroups: () -> Unit,
     onFilterChanged: (String) -> Unit,
@@ -251,11 +275,22 @@ private fun Content(
     onNewCode: (CurrencyCode) -> Unit,
 ) {
     val groups = state.pages.map { it.group }
-    Column {
+    val layoutDirection = LocalLayoutDirection.current
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .imePadding()
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                ),
+    ) {
         SearchTextField(
             modifier =
                 Modifier.padding(
-                    top = 16.dp,
+                    top = contentPadding.calculateTopPadding() + 16.dp,
                     start = 16.dp,
                     end = 16.dp,
                     bottom = 16.dp,
@@ -268,6 +303,10 @@ private fun Content(
             QuickSearchPage(
                 topResultsFiltered = state.topResultsFiltered,
                 onNewCode = onNewCode,
+                contentPadding =
+                    PaddingValues(
+                        bottom = contentPadding.calculateBottomPadding(),
+                    ),
             )
         } else {
             if (state.pages.size == 1) {
@@ -282,6 +321,10 @@ private fun Content(
                     onPin = onPin,
                     onUnpin = onUnpin,
                     onNewCode = onNewCode,
+                    contentPadding =
+                        PaddingValues(
+                            bottom = contentPadding.calculateBottomPadding(),
+                        ),
                 )
             } else {
                 GroupViewPager(
@@ -300,6 +343,10 @@ private fun Content(
                         onPin = onPin,
                         onUnpin = onUnpin,
                         onNewCode = onNewCode,
+                        contentPadding =
+                            PaddingValues(
+                                bottom = contentPadding.calculateBottomPadding(),
+                            ),
                     )
                 }
             }
@@ -319,9 +366,13 @@ private fun GroupPage(
     onClick: (QuickCalculation) -> Unit = {},
     onLongClick: (QuickCalculation) -> Unit = {},
     onNewCode: (CurrencyCode) -> Unit,
+    contentPadding: PaddingValues,
 ) {
     val ctx = LocalContext.current
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = contentPadding,
+    ) {
         if (pinned.isNotEmpty()) {
             item {
                 ListHeader(text = stringResource(CoreRString.quick_pinned_calculations))

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickSearchPage.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickSearchPage.kt
@@ -1,6 +1,9 @@
 package dev.arkbuilders.rate.feature.quick.presentation.main
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -17,9 +20,13 @@ import dev.arkbuilders.rate.core.presentation.ui.NoResult
 fun QuickSearchPage(
     topResultsFiltered: List<CurrencyInfo>,
     onNewCode: (CurrencyCode) -> Unit,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     if (topResultsFiltered.isNotEmpty()) {
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding,
+        ) {
             item {
                 ListHeader(text = stringResource(CoreRString.top_results))
             }
@@ -28,6 +35,10 @@ fun QuickSearchPage(
             }
         }
     } else {
-        NoResult()
+        NoResult(
+            Modifier
+                .padding(contentPadding)
+                .consumeWindowInsets(contentPadding),
+        )
     }
 }

--- a/feature/search/src/main/java/dev/arkbuilders/rate/feature/search/presentation/SearchCurrencyScreen.kt
+++ b/feature/search/src/main/java/dev/arkbuilders/rate/feature/search/presentation/SearchCurrencyScreen.kt
@@ -6,11 +6,13 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,7 +40,6 @@ import dev.arkbuilders.rate.core.presentation.ui.ListHeader
 import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
 import dev.arkbuilders.rate.core.presentation.ui.NoResult
 import dev.arkbuilders.rate.core.presentation.ui.SearchTextField
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
 import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.search.di.SearchComponentHolder
@@ -95,7 +96,7 @@ fun SearchCurrencyScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         Box(modifier = Modifier.fillMaxSize()) {
             if (state.initialized) {

--- a/feature/search/src/main/java/dev/arkbuilders/rate/feature/search/presentation/SearchCurrencyScreen.kt
+++ b/feature/search/src/main/java/dev/arkbuilders/rate/feature/search/presentation/SearchCurrencyScreen.kt
@@ -3,8 +3,13 @@
 package dev.arkbuilders.rate.feature.search.presentation
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -15,7 +20,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ramcosta.composedestinations.annotation.Destination
@@ -31,6 +38,9 @@ import dev.arkbuilders.rate.core.presentation.ui.ListHeader
 import dev.arkbuilders.rate.core.presentation.ui.LoadingScreen
 import dev.arkbuilders.rate.core.presentation.ui.NoResult
 import dev.arkbuilders.rate.core.presentation.ui.SearchTextField
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.feature.search.di.SearchComponentHolder
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -85,20 +95,47 @@ fun SearchCurrencyScreen(
                 onBackClick = { viewModel.onBackClick() },
             )
         },
-    ) {
-        Column(modifier = Modifier.padding(it)) {
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
             if (state.initialized) {
-                Input(state.filter, viewModel::onInputChange)
-                Results(
-                    filter = state.filter,
-                    prohibitedCodes = state.prohibitedCodes,
-                    frequent = state.frequent,
-                    all = state.all,
-                    topResultsFiltered = state.topResultsFiltered,
-                    onClick = viewModel::onClick,
-                )
+                val layoutDirection = LocalLayoutDirection.current
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .consumeWindowInsets(contentPadding)
+                            .imePadding()
+                            .padding(
+                                start = contentPadding.calculateStartPadding(layoutDirection),
+                                end = contentPadding.calculateEndPadding(layoutDirection),
+                            ),
+                ) {
+                    Input(
+                        input = state.filter,
+                        topPadding = contentPadding.calculateTopPadding(),
+                        onInputChange = viewModel::onInputChange,
+                    )
+                    Results(
+                        modifier = Modifier.weight(1f),
+                        contentPadding =
+                            PaddingValues(
+                                bottom = contentPadding.calculateBottomPadding(),
+                            ),
+                        filter = state.filter,
+                        prohibitedCodes = state.prohibitedCodes,
+                        frequent = state.frequent,
+                        all = state.all,
+                        topResultsFiltered = state.topResultsFiltered,
+                        onClick = viewModel::onClick,
+                    )
+                }
             } else {
-                LoadingScreen()
+                LoadingScreen(
+                    Modifier
+                        .padding(contentPadding)
+                        .consumeWindowInsets(contentPadding),
+                )
             }
         }
     }
@@ -107,12 +144,18 @@ fun SearchCurrencyScreen(
 @Composable
 private fun Input(
     input: String,
+    topPadding: Dp,
     onInputChange: (String) -> Unit,
 ) {
     SearchTextField(
         modifier =
             Modifier
-                .padding(16.dp)
+                .padding(
+                    start = 16.dp,
+                    top = topPadding + 16.dp,
+                    end = 16.dp,
+                    bottom = 16.dp,
+                )
                 .fillMaxWidth(),
         text = input,
         onValueChange = { onInputChange(it) },
@@ -122,6 +165,8 @@ private fun Input(
 
 @Composable
 private fun Results(
+    modifier: Modifier,
+    contentPadding: PaddingValues,
     filter: String,
     prohibitedCodes: List<CurrencyCode>,
     frequent: List<CurrencyInfo>,
@@ -132,7 +177,10 @@ private fun Results(
     when {
         filter.isNotEmpty() -> {
             if (topResultsFiltered.isNotEmpty()) {
-                LazyColumn {
+                LazyColumn(
+                    modifier = modifier.fillMaxSize(),
+                    contentPadding = contentPadding,
+                ) {
                     item { ListHeader(stringResource(CoreRString.top_results)) }
                     items(topResultsFiltered) { model ->
                         SearchCurrencyInfoItem(
@@ -142,12 +190,19 @@ private fun Results(
                     }
                 }
             } else {
-                NoResult()
+                NoResult(
+                    modifier
+                        .padding(contentPadding)
+                        .consumeWindowInsets(contentPadding),
+                )
             }
         }
 
         else -> {
-            LazyColumn {
+            LazyColumn(
+                modifier = modifier.fillMaxSize(),
+                contentPadding = contentPadding,
+            ) {
                 if (frequent.isNotEmpty()) {
                     item { ListHeader(stringResource(CoreRString.frequent_currencies)) }
                     items(frequent) { model ->

--- a/feature/settings/src/main/java/dev/arkbuilders/rate/feature/settings/presentation/AboutScreen.kt
+++ b/feature/settings/src/main/java/dev/arkbuilders/rate/feature/settings/presentation/AboutScreen.kt
@@ -1,5 +1,6 @@
 package dev.arkbuilders.rate.feature.settings.presentation
 
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -13,6 +14,7 @@ import dev.arkbuilders.components.about.presentation.ArkAbout
 import dev.arkbuilders.rate.core.presentation.CoreRDrawable
 import dev.arkbuilders.rate.core.presentation.CoreRString
 import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.feature.settings.di.SettingsComponentHolder
 
 @Destination<ExternalModuleGraph>
@@ -27,9 +29,13 @@ fun AboutScreen(navigator: DestinationsNavigator) {
                 onBackClick = { navigator.popBackStack() },
             )
         },
-    ) {
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
         ArkAbout(
-            modifier = Modifier.padding(it),
+            modifier =
+                Modifier
+                    .padding(contentPadding)
+                    .consumeWindowInsets(contentPadding),
             appName = stringResource(id = CoreRString.app_name),
             appLogoResId = CoreRDrawable.ic_app_logo,
             versionName = component.buildConfigFields().versionName,

--- a/feature/settings/src/main/java/dev/arkbuilders/rate/feature/settings/presentation/AboutScreen.kt
+++ b/feature/settings/src/main/java/dev/arkbuilders/rate/feature/settings/presentation/AboutScreen.kt
@@ -1,7 +1,9 @@
 package dev.arkbuilders.rate.feature.settings.presentation
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -14,7 +16,6 @@ import dev.arkbuilders.components.about.presentation.ArkAbout
 import dev.arkbuilders.rate.core.presentation.CoreRDrawable
 import dev.arkbuilders.rate.core.presentation.CoreRString
 import dev.arkbuilders.rate.core.presentation.ui.AppTopBarBack
-import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
 import dev.arkbuilders.rate.feature.settings.di.SettingsComponentHolder
 
 @Destination<ExternalModuleGraph>
@@ -29,7 +30,7 @@ fun AboutScreen(navigator: DestinationsNavigator) {
                 onBackClick = { navigator.popBackStack() },
             )
         },
-        contentWindowInsets = appScaffoldContentWindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         ArkAbout(
             modifier =

--- a/feature/settings/src/main/java/dev/arkbuilders/rate/feature/settings/presentation/SettingsScreen.kt
+++ b/feature/settings/src/main/java/dev/arkbuilders/rate/feature/settings/presentation/SettingsScreen.kt
@@ -5,8 +5,11 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -44,6 +48,9 @@ import dev.arkbuilders.rate.core.presentation.CoreRString
 import dev.arkbuilders.rate.core.presentation.theme.ArkColor
 import dev.arkbuilders.rate.core.presentation.ui.AppHorDiv
 import dev.arkbuilders.rate.core.presentation.ui.AppHorDiv16
+import dev.arkbuilders.rate.core.presentation.ui.appScaffoldContentWindowInsets
+import dev.arkbuilders.rate.core.presentation.ui.calculateEndPadding
+import dev.arkbuilders.rate.core.presentation.ui.calculateStartPadding
 import dev.arkbuilders.rate.core.presentation.utils.DateFormatUtils
 import dev.arkbuilders.rate.feature.settings.di.SettingsComponentHolder
 import dev.arkbuilders.rate.feature.settings.domain.model.AppLanguage
@@ -78,24 +85,26 @@ fun SettingsScreen(navigator: DestinationsNavigator) {
         }
     }
 
-    Scaffold {
-        Box(modifier = Modifier.padding(it)) {
-            Content(
-                state = state,
-                navigator = navigator,
-                onCrashReportsToggle = viewModel::onCrashReportToggle,
-                onAnalyticsToggle = viewModel::onAnalyticsToggle,
-                onToggleLanguagePopup = viewModel::onToggleLanguagePopup,
-                onChangeLanguage = viewModel::onChangeLanguage,
-                onAboutClick = viewModel::onAboutClick,
-            )
-        }
+    Scaffold(
+        contentWindowInsets = appScaffoldContentWindowInsets(),
+    ) { contentPadding ->
+        Content(
+            state = state,
+            contentPadding = contentPadding,
+            navigator = navigator,
+            onCrashReportsToggle = viewModel::onCrashReportToggle,
+            onAnalyticsToggle = viewModel::onAnalyticsToggle,
+            onToggleLanguagePopup = viewModel::onToggleLanguagePopup,
+            onChangeLanguage = viewModel::onChangeLanguage,
+            onAboutClick = viewModel::onAboutClick,
+        )
     }
 }
 
 @Composable
 private fun Content(
     state: SettingsScreenState,
+    contentPadding: PaddingValues,
     navigator: DestinationsNavigator,
     onCrashReportsToggle: (Boolean) -> Unit,
     onAnalyticsToggle: (Boolean) -> Unit,
@@ -105,11 +114,19 @@ private fun Content(
 ) {
     val ctx = LocalContext.current
     val resources = LocalResources.current
+    val layoutDirection = LocalLayoutDirection.current
     Column(
         modifier =
             Modifier
-                .padding(vertical = 32.dp)
-                .verticalScroll(rememberScrollState()),
+                .fillMaxSize()
+                .consumeWindowInsets(contentPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    top = contentPadding.calculateTopPadding() + 32.dp,
+                    end = contentPadding.calculateEndPadding(layoutDirection),
+                    bottom = contentPadding.calculateBottomPadding() + 32.dp,
+                ),
     ) {
         Text(
             modifier = Modifier.padding(horizontal = 16.dp),


### PR DESCRIPTION
## 📌 Description
- Apply correct edge-to-edge inset handling across the app
- Fix system bar and IME padding on onboarding and content screens
- Correct bottom navigation insets
- Smooth bottom navigation and FAB transitions
- Prevent bottom action buttons from jumping during navigation
- Keep the gesture navigation area reserved when the bottom bar is hidden

## Motivation

This change establishes consistent full-screen layout and inset handling across the app. It also prepares the UI structure for the dark theme migration.