### PR TITLE
Fix quick widget crashes and empty state

### DIFF
--- a/app/src/main/java/dev/arkbuilders/rate/presentation/MainScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/MainScreen.kt
@@ -35,8 +35,10 @@ import com.ramcosta.composedestinations.generated.quick.destinations.QuickScreen
 import com.ramcosta.composedestinations.generated.settings.destinations.SettingsScreenDestination
 import com.ramcosta.composedestinations.manualcomposablecalls.composable
 import com.ramcosta.composedestinations.navargs.primitives.longNavType
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.rememberNavHostEngine
 import com.ramcosta.composedestinations.scope.resultRecipient
+import com.ramcosta.composedestinations.utils.rememberDestinationsNavigator
 import com.ramcosta.composedestinations.utils.startDestination
 import dev.arkbuilders.rate.core.domain.repo.AnalyticsManager
 import dev.arkbuilders.rate.core.domain.repo.NetworkStatus
@@ -67,10 +69,11 @@ private val showBottomBarRoutes =
 fun MainScreen() {
     val engine = rememberNavHostEngine()
     val navController = engine.rememberNavController()
+    val destinationsNavigator = navController.rememberDestinationsNavigator()
     val snackState = remember { SnackbarHostState() }
     val coreComponent = App.instance.coreComponent
 
-    HandleAddQuickCalculationIntentEffect(navController)
+    HandleAddQuickCalculationIntentEffect(destinationsNavigator)
 
     ObserveNetworkStatusEffect(
         networkStatus = coreComponent.networkStatus(),
@@ -184,7 +187,7 @@ fun MainScreen() {
 }
 
 @Composable
-private fun HandleAddQuickCalculationIntentEffect(navController: NavController) {
+private fun HandleAddQuickCalculationIntentEffect(navigator: DestinationsNavigator) {
     val ctx = LocalContext.current
     LaunchedEffect(key1 = Unit) {
         val activity = ctx.findActivity()
@@ -192,7 +195,7 @@ private fun HandleAddQuickCalculationIntentEffect(navController: NavController) 
         val createNewCalc = intent?.getStringExtra(ADD_NEW_CALCULATION) ?: ""
         if (createNewCalc.isNotEmpty()) {
             val groupId = intent?.getLongExtra(ADD_NEW_CALCULATION_GROUP_KEY, 0L)
-            navController.navigate(AddQuickScreenDestination(groupId = groupId))
+            navigator.navigate(AddQuickScreenDestination(groupId = groupId))
             intent?.removeExtra(ADD_NEW_CALCULATION_GROUP_KEY)
             intent?.removeExtra(ADD_NEW_CALCULATION)
         }

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/MainScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/MainScreen.kt
@@ -194,7 +194,10 @@ private fun HandleAddQuickCalculationIntentEffect(navigator: DestinationsNavigat
         val intent = activity?.intent
         val createNewCalc = intent?.getStringExtra(ADD_NEW_CALCULATION) ?: ""
         if (createNewCalc.isNotEmpty()) {
-            val groupId = intent?.getLongExtra(ADD_NEW_CALCULATION_GROUP_KEY, 0L)
+            val groupId =
+                intent
+                    ?.takeIf { it.hasExtra(ADD_NEW_CALCULATION_GROUP_KEY) }
+                    ?.getLongExtra(ADD_NEW_CALCULATION_GROUP_KEY, 0L)
             navigator.navigate(AddQuickScreenDestination(groupId = groupId))
             intent?.removeExtra(ADD_NEW_CALCULATION_GROUP_KEY)
             intent?.removeExtra(ADD_NEW_CALCULATION)

--- a/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/QuickCalculationsWidget.kt
+++ b/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/QuickCalculationsWidget.kt
@@ -54,7 +54,6 @@ class QuickCalculationsWidget : GlanceAppWidget() {
             val groupId = prefs[QuickCalculationsWidgetReceiver.currentGroupIdKey]
             val quickCalculationsList = pinned.filter { it.calculation.group.id == groupId }
             val displayGroup = groups.find { it.id == groupId }
-            displayGroup ?: return@provideContent
             Column(
                 modifier =
                     GlanceModifier.fillMaxSize().background(Color.White)
@@ -80,30 +79,32 @@ class QuickCalculationsWidget : GlanceAppWidget() {
                                 fontWeight = FontWeight.Medium,
                             ),
                     )
-                    Text(
-                        modifier = GlanceModifier.defaultWeight(),
-                        text = displayGroup.name,
-                        style =
-                            TextStyle(
-                                color = ColorProvider(ArkColor.TextTertiary),
-                                fontWeight = FontWeight.Medium,
-                            ),
-                    )
-                    Image(
-                        modifier =
-                            GlanceModifier.size(24.dp).padding(4.dp)
-                                .clickable(actionRunCallback<PreviousPageAction>()),
-                        provider = ImageProvider(CoreRDrawable.ic_chevron_left),
-                        contentDescription = null,
-                    )
+                    displayGroup?.let { group ->
+                        Text(
+                            modifier = GlanceModifier.defaultWeight(),
+                            text = group.name,
+                            style =
+                                TextStyle(
+                                    color = ColorProvider(ArkColor.TextTertiary),
+                                    fontWeight = FontWeight.Medium,
+                                ),
+                        )
+                        Image(
+                            modifier =
+                                GlanceModifier.size(24.dp).padding(4.dp)
+                                    .clickable(actionRunCallback<PreviousPageAction>()),
+                            provider = ImageProvider(CoreRDrawable.ic_chevron_left),
+                            contentDescription = null,
+                        )
 
-                    Image(
-                        modifier =
-                            GlanceModifier.size(24.dp).padding(4.dp)
-                                .clickable(actionRunCallback<NextPageAction>()),
-                        provider = ImageProvider(CoreRDrawable.ic_chevron_right),
-                        contentDescription = null,
-                    )
+                        Image(
+                            modifier =
+                                GlanceModifier.size(24.dp).padding(4.dp)
+                                    .clickable(actionRunCallback<NextPageAction>()),
+                            provider = ImageProvider(CoreRDrawable.ic_chevron_right),
+                            contentDescription = null,
+                        )
+                    }
                     Image(
                         modifier =
                             GlanceModifier.size(24.dp).padding(4.dp)

--- a/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/action/AddNewCalculationAction.kt
+++ b/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/action/AddNewCalculationAction.kt
@@ -23,7 +23,7 @@ class AddNewCalculationAction : ActionCallback {
             Intent().apply {
                 setClassName(context, "dev.arkbuilders.rate.presentation.MainActivity")
                 putExtra(ADD_NEW_CALCULATION, "ADD_NEW_CALCULATION")
-                putExtra(ADD_NEW_CALCULATION_GROUP_KEY, groupId)
+                groupId?.let { putExtra(ADD_NEW_CALCULATION_GROUP_KEY, it) }
                 setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             },
         )


### PR DESCRIPTION
## 📌 Description
- Fix navigation crash when opening calculation creation from the widget
- Show the widget empty state when there are no calculations or groups
- Create the default group when adding the first calculation from the widget

## How to test
1. Uninstall and reinstall the app.
2. Add the Quick Calculations widget without creating any calculations first.
3. Verify the widget shows its empty state instead of being transparent.
4. Tap the add button in the widget and verify the calculation creation screen opens without crashing.
5. Save the calculation and verify the Default group is created.
6. Verify the newly created calculation can be pinned and displayed in the widget.
